### PR TITLE
increase version to 1.0.1 + add CITATION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: treerabid
 Title: Reconstruct Rabies Transmission Trees
-Version: 0.0.1.0000
+Version: 1.0.1.0000
 Authors@R: 
     person(given = "Malavika",
            family = "Rajeev",

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,8 @@
+bibentry(
+  bibtype  = "Manual",
+  title    = "treerabid: Reconstruct Rabies Transmission Trees",
+  author   = "Malavika Rajeev",
+  year     = "2024",
+  note     = "R package version 1.0.1",
+  url      = "https://github.com/mrajeev08/treerabid/"
+)


### PR DESCRIPTION
Hi Malavika,

Ava Yuson from Katie's group is publishing a paper for which we're using the updated/debugged treerabid, and we thought it would be useful to cite the correct version of the package.

So, I've increased the version number (was still 0.0.1 in DESCRIPTION, but elsewhere you've referred to the released version as 1.0, so I've changed the latest to 1.0.1) and have added a CITATION file with version 1.0.1.

I've not added another "release", but instead was going to suggest changing the url in the citation in the paper to the one for the exact commit.

Are you okay with this? Or alternatively could you add another release for current version 1.0.1 to Zenodo and add the doi?

Thank you,

Carlijn